### PR TITLE
Add python3 and python3-doc

### DIFF
--- a/external/alpine_iso/packages.txt
+++ b/external/alpine_iso/packages.txt
@@ -82,6 +82,8 @@ openssl
 openssl-doc
 p11-kit-doc
 popt-doc
+python3
+python3-doc
 readline-doc
 sfdisk
 ssmtp


### PR DESCRIPTION
Add python3 and python3-doc. Increases size by about 19MB and makes vmConsole much more useful if installed by default.